### PR TITLE
bumping riakpbc to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "configya": "~0.0.6",
     "lodash": "~2.4.1",
-    "riakpbc": "git://github.com/nlf/riakpbc.git#riak2",
+    "riakpbc": "~2.0.1",
     "sliver": "~0.0.2",
     "solr-client": "~0.2.9",
     "when": "~3.0.0"


### PR DESCRIPTION
We're seeing some weird errors in NPM:

`Failed resolving git HEAD (git://github.com/nlf/riakpbc.git) fatal: ambiguous argument 'riak2': unknown revision or path not in the working tree.``

Can we go back to a proper npm version at this point?
